### PR TITLE
QX-27487 inlineViewerFontIssues Version2026.1 master

### DIFF
--- a/gulpfile.mjs
+++ b/gulpfile.mjs
@@ -2272,11 +2272,11 @@ gulp.task(
   gulp.series("clean", "generic", function packageMcBuild(done) {
     const targetName = getTargetName();
     gulp
-      .src(BUILD_DIR + "generic/**")
+      .src(BUILD_DIR + "generic/**", { encoding: false })
       .pipe(gulp.dest(MC_DIR))
       .on("end", function () {
         gulp
-          .src(MC_DIR + "**", { base: BUILD_DIR })
+          .src(MC_DIR + "**", { base: BUILD_DIR, encoding: false })
           .pipe(zip(targetName))
           .pipe(gulp.dest(BUILD_DIR))
           .on("end", function () {


### PR DESCRIPTION
The cmap files are being corrupted during the mc-build process because the binary cmap files are being treated as text files and corrupted when copied.

I guess when gulp reads binary files without encoding: false, it interprets them as UTF-8 text, which corrupts the binary data by expanding certain byte sequences. So we'll add { encoding: false } to both gulp.src() calls in the mc-build task.
